### PR TITLE
Spike: detach block that is called before returning objects to the available pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,22 @@ Options:
 * :collection - How to manage the objects in the pool. The default is :queue, meaning that pond.checkout will yield the object that hasn't been used in the longest period of time. This is to prevent connections from becoming 'stale'. The alternative is :stack, so checkout will yield the object that has most recently been returned to the pool. This would be preferable if you're using connections that have their own logic for becoming idle in periods of low activity.
 * :eager - Set this to true to fill the pool with instantiated objects when it is created, similar to how `connection_pool` works.
 
+### Detaching Closed Connections ###
+
+```ruby
+  require 'pond'
+  require 'pg'
+
+  pond = Pond.new(:maximum_size => 5, :timeout => 0.5) {PG.connect({:dbname => "pond_test"})}
+
+  # Use #detach_if= to set a lambda (or any object that responds to #call)
+  #   to determine if the yielded object should be returned to the pool or
+  #   if it should be detached/dropped instead
+  # Return `true` if it should be dropped, `false` otherwise
+  pond.detach_if = lambda {|connection| connection.finished?}
+
+```
+
 ## Contributing
 
 I don't plan on adding too many more features to Pond, since I want to keep its design simple. If there's something you'd like to see it do, open an issue so we can discuss it before going to the trouble of creating a pull request.

--- a/spec/checkout_spec.rb
+++ b/spec/checkout_spec.rb
@@ -12,6 +12,22 @@ describe Pond, "#checkout" do
     value.should == 'value'
   end
 
+  it 'removes the object from the pool if detach_if block returns true' do
+    int = 0
+    pond = Pond.new { int += 1 }
+    pond.detach_if = lambda {|obj| obj < 2 }
+
+    # allocate 1, should not check back in
+    pond.checkout {|i| i.should == 1}
+    # allocate 2, should be nothing else in the pond
+    pond.checkout do |i|
+      i.should == 2
+      pond.available.should == []
+    end
+    # 2 should still be in the pond
+    pond.available.should == [2]
+  end
+
   it "should instantiate objects when needed" do
     int  = 0
     pond = Pond.new { int += 1 }


### PR DESCRIPTION
Not sure this handles the case of `current_object` yet. But I'm still tracing that.
