### PR TITLE
MRI 2.7

### DIFF
--- a/lib/pond.rb
+++ b/lib/pond.rb
@@ -21,7 +21,7 @@ class Pond
   )
     @block   = block
     @monitor = Monitor.new
-    @cv      = Monitor::ConditionVariable.new(@monitor)
+    @cv      = MonitorMixin::ConditionVariable.new(@monitor)
 
     @allocated = {}
     @available = Array.new(eager ? maximum_size : 0, &block)

--- a/pond.gemspec
+++ b/pond.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.3'
-  spec.add_development_dependency 'rspec',   '~> 2.14'
+  spec.add_development_dependency 'bundler', '>= 1.3'
+  spec.add_development_dependency 'rspec',   '>= 2.14'
   spec.add_development_dependency 'rake'
 end


### PR DESCRIPTION
This pull request consists of two changes:
1) MRI 2.7 seems to have [changed](https://bugs.ruby-lang.org/issues/16255) `Monitor` implementation so that it no longer `include`s `MonitorMixin`. `ConditionVariable` is still available under `MonitorMixin` module so `MonitorMixin::ConditionVariable` is used instead of `Monitor::ConditionVariable`.

2) (optional) MRI 2.7 comes with `bundler` 2.1.2 and as it seems to work fine with `pond` so the upper bound on the dev dependency version restriction was deleted. `rspec` 2.* does not work with `rake` 13.0 (and running `rake` 12.0 and below results in many warnings running with MRI 2.7, though still seems to work fine), so I have also removed the upper bound on the `rspec` dev dependency (tests pass for me with the latest `rspec` 3.9.0 version). Let me know if you want to set a custom higher bound for those dependencies or feel free to omit that commit altogether as it is not needed for the library dependants to function.

Tested with all supported MRI versions on Travis CI: https://travis-ci.org/gekola/pond/builds/631109521
Unfortunately, I could not bring Rubinius to run on there.